### PR TITLE
Serve React build via Express

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -10,6 +10,7 @@ const EsphomeApi = require('esphome-native-api');
 const app = express();
 app.use(cors());
 app.use(express.json());
+app.use(express.static(path.join(__dirname, '..', 'dist')));
 
 const HTTP_PORT = process.env.HTTP_PORT || 8080;
 const devicesFile = path.join(__dirname, 'devices.json');
@@ -104,6 +105,11 @@ app.get('/api/devices/:id/status', async (req, res) => {
   device.online = online;
   res.json({ online });
 });
+
+// Serve React app for all remaining routes
+app.get('*', (req, res) =>
+  res.sendFile(path.join(__dirname, '..', 'dist', 'index.html'))
+);
 
 const server = app.listen(HTTP_PORT, '0.0.0.0', () => {
   console.log(`Server listening on ${HTTP_PORT}`);


### PR DESCRIPTION
## Summary
- expose `/dist` via Express static middleware
- fall back to `index.html` for non-API routes

## Testing
- `npm run build`
- `npm start` then `curl http://localhost:8080/`

------
https://chatgpt.com/codex/tasks/task_e_687d57e8a0e88330beeccac1cf0fc6e1