### PR TITLE
Serve built UI in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,11 @@ Aplicação fullstack para gerir dispositivos ESPHome na rede local.
 - `npm run build` compila o frontend para `dist/`
 - `npm start` arranca o servidor
 
+Para instalar dependências e iniciar o servidor de produção automaticamente,
+basta executar:
+
+```bash
+bash setup.sh
+```
+
 O servidor expõe API REST e WebSocket para monitorizar dispositivos.

--- a/server/index.js
+++ b/server/index.js
@@ -10,6 +10,8 @@ const EsphomeApi = require('esphome-native-api');
 const app = express();
 app.use(cors());
 app.use(express.json());
+// Serve the built client files from ../dist when running in production
+app.use(express.static(path.join(__dirname, '..', 'dist')));
 
 const HTTP_PORT = process.env.HTTP_PORT || 8080;
 const devicesFile = path.join(__dirname, 'devices.json');
@@ -103,6 +105,11 @@ app.get('/api/devices/:id/status', async (req, res) => {
   const online = await checkOnline(device.ip, device.port);
   device.online = online;
   res.json({ online });
+});
+
+// SPA fallback: serve index.html for any other route
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, '..', 'dist', 'index.html'));
 });
 
 const server = app.listen(HTTP_PORT, '0.0.0.0', () => {


### PR DESCRIPTION
## Summary
- serve the built frontend from Express
- add SPA fallback route
- document running `bash setup.sh` to install dependencies and start the server

## Testing
- `npm test` *(fails: Missing script)*
- `bash setup.sh` *(starts server successfully)*
- `curl -I http://localhost:8080`

------
https://chatgpt.com/codex/tasks/task_e_687d57f1d2cc8330aeda39b632e1f37d